### PR TITLE
fix: prevent nil dereference on unstructuredobject

### DIFF
--- a/apply.go
+++ b/apply.go
@@ -195,6 +195,9 @@ func (c *Client) Apply(namespace string, objects ...runtime.Object) error {
 		}
 		client, _, unstructuredObj, err := c.GetDynamicClientFor(namespace, obj)
 		if IsAPIResourceMissing(err) {
+			if unstructuredObj == nil {
+				return err
+			}
 			if err := c.WaitForAPIResource(unstructuredObj.GetAPIVersion(), unstructuredObj.GetKind(), 3*time.Minute); err != nil {
 				return err
 			}


### PR DESCRIPTION
`unstrtucturedObj` can be `nil` when the API resource is missing. The issue I ran into was that karina was deploying a Grafana kind, which referenced a CRD that was not defined. This was caused by running a dry-run without deploying first. The dry-run did not create the required CRDs, causing failures further down the line