### PR TITLE
feat: update functions struct to use kommons.client and kget to searc…

### DIFF
--- a/ktemplate/functions.go
+++ b/ktemplate/functions.go
@@ -1,17 +1,17 @@
 package ktemplate
 
 import (
+	"github.com/flanksource/kommons"
 	"text/template"
 
 	gomplate "github.com/hairyhenderson/gomplate/v3"
-	"k8s.io/client-go/kubernetes"
 )
 
 type Functions struct {
-	clientset *kubernetes.Clientset
+	clientset *kommons.Client
 }
 
-func NewFunctions(clientset *kubernetes.Clientset) *Functions {
+func NewFunctions(clientset *kommons.Client) *Functions {
 	return &Functions{clientset: clientset}
 }
 

--- a/ktemplate/kget.go
+++ b/ktemplate/kget.go
@@ -1,14 +1,11 @@
 package ktemplate
 
 import (
-	"context"
 	"encoding/json"
 	"strings"
 
 	"github.com/flanksource/commons/logger"
 	"github.com/tidwall/gjson"
-	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func (f *Functions) KGet(path, jsonpath string) string {
@@ -22,41 +19,44 @@ func (f *Functions) KGet(path, jsonpath string) string {
 	namespace := parts[1]
 	name := parts[2]
 
-	if kind == "configmap" || kind == "cm" {
-		cm, err := f.clientset.CoreV1().ConfigMaps(namespace).Get(context.Background(), name, metav1.GetOptions{})
-		if err != nil {
-			if !errors.IsNotFound(err) {
-				logger.Errorf("failed to read configmap name %s namespace %s: %v", name, namespace, err)
-			}
+	if kind == "configmap" || kind == "cm" || kind == "ConfigMap" {
+		configMapData := f.clientset.GetConfigMap(namespace, name)
+		if configMapData == nil {
+			logger.Errorf("failed to read configmap name %s namespace %s: %v", name, namespace)
 			return ""
 		}
 
-		encodedJSON, err := json.Marshal(cm)
+		data := *configMapData
+		return data[jsonpath]
+	} else if kind == "secret" || kind == "Secret" {
+		secretData := f.clientset.GetSecret(namespace, name)
+		if secretData == nil {
+			logger.Errorf("failed to read secret name %s namespace %s: %v", name, namespace)
+			return ""
+		}
+		data := *secretData
+		return string(data[jsonpath])
+	} else if kind == "service" || kind == "svc" {
+		svc, err := f.clientset.GetByKind("Service", namespace, name)
+		if svc == nil || err != nil {
+			logger.Errorf("failed to read service name %s namespace %s: %v", name, namespace, err)
+			return ""
+		}
+
+		encodedJSON, err := json.Marshal(svc.Object)
 		if err != nil {
 			logger.Errorf("failed to encode json name %s namespace %s: %v", name, namespace, err)
 			return ""
 		}
 		value := gjson.Get(string(encodedJSON), jsonpath)
 		return value.String()
-	} else if kind == "secret" {
-		secret, err := f.clientset.CoreV1().Secrets(namespace).Get(context.Background(), name, metav1.GetOptions{})
-		if err != nil {
-			if !errors.IsNotFound(err) {
-				logger.Errorf("failed to read secret name %s namespace %s: %v", name, namespace, err)
-			}
+	} else if kind != "" {
+		object, err := f.clientset.GetByKind(kind, namespace, name)
+		if object == nil || err != nil {
+			logger.Errorf("failed to read %s name %s namespace %s: %v", kind, name, namespace, err)
 			return ""
 		}
-		return string(secret.Data[jsonpath])
-	} else if kind == "service" || kind == "svc" {
-		svc, err := f.clientset.CoreV1().Services(namespace).Get(context.Background(), name, metav1.GetOptions{})
-		if err != nil {
-			if !errors.IsNotFound(err) {
-				logger.Errorf("failed to read service name %s namespace %s: %v", name, namespace, err)
-			}
-			return ""
-		}
-
-		encodedJSON, err := json.Marshal(svc)
+		encodedJSON, err := json.Marshal(object.Object)
 		if err != nil {
 			logger.Errorf("failed to encode json name %s namespace %s: %v", name, namespace, err)
 			return ""

--- a/ktemplate/structtemplater.go
+++ b/ktemplate/structtemplater.go
@@ -1,14 +1,14 @@
 package ktemplate
 
 import (
-	"k8s.io/client-go/kubernetes"
+	"github.com/flanksource/kommons"
 	"reflect"
 	"strings"
 )
 
 type StructTemplater struct {
 	Values    map[string]string
-	Clientset *kubernetes.Clientset
+	Clientset *kommons.Client
 	functions *Functions
 }
 


### PR DESCRIPTION
…h arbitary object

After some changes on the template-operator side for this change. Tested it with the template operator using ` '{{kget "Service/test/my-cs" "spec.type"}}'`  in the template and verified the created object... works as expected 


Signed-off-by: Tarun Khandelwal <tarun@flanksource.com>